### PR TITLE
Fix package source issue

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include README
+include setup.py
+recursive-include . *.py *.c
+recursive-include clinic *.h

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ darwin_module = Extension('_posixshmem',
                     sources = ['posixshmem.c'])
 
 setup (name = 'shared-memory-backport',
-       version = '1.1.1',
+       version = '2.0.0',
        description = 'Simple backport of the multiprocessing.shared_memory module freshlay landed in python 3.8',
        py_modules = ['shared_memory'],
        ext_modules = [linux_module] if platform.system() == 'Linux' else [darwin_module] if platform.system() == 'Darwin' else []


### PR DESCRIPTION
There was an issue making it impossible to include the proper files to create a package archive (using `python setup.py sdist`).
As well, it made the package (using `pip install git+ssh://....` ) not usable with pipenv or poetry, since the used files were not properly declared.
This PR add a MANIFEST.in specifying the necessary files to perform the build.

As well, it will help to deploy the package to pypi as asked by #3 .